### PR TITLE
Fix build with newest tools.

### DIFF
--- a/build/Android.common_build.mk
+++ b/build/Android.common_build.mk
@@ -72,7 +72,7 @@ ART_TARGET_CFLAGS :=
 
 # Host.
 ART_HOST_CLANG := false
-ifneq ($(WITHOUT_HOST_CLANG),true)
+ifeq ($(WITHOUT_HOST_CLANG),false)
   # By default, host builds use clang for better warnings.
   ART_HOST_CLANG := true
 endif

--- a/build/Android.common_build.mk
+++ b/build/Android.common_build.mk
@@ -72,6 +72,12 @@ ART_TARGET_CFLAGS :=
 
 # Host.
 ART_HOST_CLANG := false
+
+ifeq ($(HOST_OS),darwin)
+  # Local darwin gcc is ancient
+  WITHOUT_HOST_CLANG ?= false
+endif
+
 ifeq ($(WITHOUT_HOST_CLANG),false)
   # By default, host builds use clang for better warnings.
   ART_HOST_CLANG := true


### PR DESCRIPTION
BinUtils & a few other tools recent updates in Debian and Ubuntu Repositories makes these necessary. Otherwise we get ART Host Library errors.

This has no effect on the end user, or anyone using the old version of said tools. The only effect is the ability to build for users who updated these tools.

